### PR TITLE
Seller id support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,12 @@ Initialization
     >>> from alipay import Alipay
     >>> alipay = Alipay(pid='your_alipay_pid', key='your_alipay_key', seller_email='your_seller_mail')
 
+Or you can use `seller_id` instead of `seller_email`:
+
+::
+
+    >>> alipay = Alipay(pid='your_alipay_pid', key='your_alipay_key', seller_id='your_seller_id')
+
 Generate direct payment url (生成即时到账支付链接)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/alipay/__init__.py
+++ b/src/alipay/__init__.py
@@ -34,13 +34,19 @@ class Alipay(object):
     sign_tuple = ('sign_type', 'MD5', 'MD5')
     sign_key = False
 
-    def __init__(self, pid, key, seller_email):
+    def __init__(self, pid, key, seller_email=None, seller_id=None):
         self.key = key
         self.pid = pid
         self.default_params = {'_input_charset': 'utf-8',
                                'partner': pid,
-                               'seller_email': seller_email,
                                'payment_type': '1'}
+        # 优先使用 seller_id （与接口端的行为一致）
+        if seller_id is not None:
+            self.default_params['seller_id'] = seller_id
+        elif seller_email is not None:
+            self.default_params['seller_email'] = seller_email
+        else:
+            raise ParameterValueError("seller_email and seller_id must have one.")
 
     def _generate_md5_sign(self, params):
         src = '&'.join(['%s=%s' % (key, value) for key,
@@ -75,7 +81,7 @@ class Alipay(object):
 
         if not kw.get('total_fee') and \
            not (kw.get('price') and kw.get('quantity')):
-            raise ParameterValueError('total_fee or (price && quantiry) must have one')
+            raise ParameterValueError('total_fee or (price && quantiry) must have one.')
 
         url = self._build_url('create_direct_pay_by_user', **kw)
         return url

--- a/src/alipay/exceptions.py
+++ b/src/alipay/exceptions.py
@@ -9,7 +9,7 @@ class MissingParameter(AlipayException):
 
 class ParameterValueError(AlipayException):
     """Raised when parameter value is incorrect"""
-    
+
+
 class TokenAuthorizationError(AlipayException):
-    '''The error occurred when getting token 
-    '''
+    '''The error occurred when getting token '''

--- a/src/alipay/tests.py
+++ b/src/alipay/tests.py
@@ -2,18 +2,18 @@
 # encoding: utf-8
 import unittest
 import six
+from xml.etree import ElementTree
 if six.PY3:
     from urllib.parse import parse_qs, urlparse
 else:
     from urlparse import parse_qs, urlparse
-from xml.etree import ElementTree
 
 
 class AlipayTests(unittest.TestCase):
     def Alipay(self, *a, **kw):
         from alipay import Alipay
         return Alipay(*a, **kw)
-    
+
     def WapAlipay(self, *a, **kw):
         from alipay import WapAlipay
         return WapAlipay(*a, **kw)
@@ -22,7 +22,7 @@ class AlipayTests(unittest.TestCase):
         self.alipay = self.Alipay(pid='pid', key='key',
                                   seller_email='lxneng@gmail.com')
         self.wapalipay = self.WapAlipay(pid='pid', key='key',
-                                  seller_email='lxneng@gmail.com')
+                                        seller_email='lxneng@gmail.com')
 
     def test_create_direct_pay_by_user_url(self):
         params = {'out_trade_no': '1',
@@ -81,8 +81,7 @@ class AlipayTests(unittest.TestCase):
                           **params)
 
     def test_raise_parameter_value_error_when_initializing(self):
-        from .exceptions import MissingParameter
-        faile_alipay = self.Alipay(pid='pid', key='key')
+        from .exceptions import ParameterValueError
         self.assertRaises(ParameterValueError,
                           self.Alipay(pid='pid', key='key'))
 
@@ -98,15 +97,15 @@ class AlipayTests(unittest.TestCase):
         self.assertIn('req_data', params)
         self.assertIn('sec_id', params)
         tree = ElementTree.ElementTree(ElementTree.fromstring(params['req_data'][0]))
-        self.assertEqual(self.wapalipay.TOKEN_ROOT_NODE, tree.getroot().tag) 
-    
+        self.assertEqual(self.wapalipay.TOKEN_ROOT_NODE, tree.getroot().tag)
+
     def test_wap_notimplemented_pay(self):
-        params= {}
+        params = {}
         self.assertRaises(NotImplementedError,
                           self.wapalipay.trade_create_by_buyer_url, **params)
         self.assertRaises(NotImplementedError,
                           self.wapalipay.create_partner_trade_by_buyer_url, **params)
-        
+
     def test_wap_unauthorization_token(self):
         from .exceptions import TokenAuthorizationError
         params = {'out_trade_no': '1',
@@ -116,14 +115,14 @@ class AlipayTests(unittest.TestCase):
                   'call_back_url': 'http://mydomain.com/alipay/callback'}
         self.assertRaises(TokenAuthorizationError,
                           self.wapalipay.create_direct_pay_by_user_url, **params)
-        
+
     def test_wap_notifyurl(self):
         '''valid MD5 sign
         invalid notify id but should not throw any exception
-        
+
         sec_id=MD5&v=1.0&notify_data=<notify><payment_type>1</payment_type><subject>测试</subject><trade_no>2014080239826696</trade_no><buyer_email>xxx@gmail.com</buyer_email><gmt_create>2014-08-02 14:49:13</gmt_create><notify_type>trade_status_sync</notify_type><quantity>1</quantity><out_trade_no>BD8Y9JQ2LT8MVXLMT34RTUWEMMBAXMIGBVQGF5CQNZHPYPQHSD4MEI56NQD2OLNV</out_trade_no><notify_time>2014-08-02 15:14:25</notify_time><seller_id>2088411445328172</seller_id><trade_status>TRADE_FINISHED</trade_status><is_total_fee_adjust>N</is_total_fee_adjust><total_fee>0.03</total_fee><gmt_payment>2014-08-02 14:49:27</gmt_payment><seller_email>lxneng@gmail.com</seller_email><gmt_close>2014-08-02 14:49:27</gmt_close><price>0.03</price><buyer_id>2088002293077967</buyer_id><notify_id>6a40ac71fcf17d99b5274b0c6c8970ea7c</notify_id><use_coupon>N</use_coupon></notify>&service=alipay.wap.trade.create.direct&sign=1f0a524dc51ed5bfc7ee2bac62e39534
         '''
-        params = {'sec_id':'MD5', 'v':'1.0',
+        params = {'sec_id': 'MD5', 'v': '1.0',
                   'notify_data': u'<notify><payment_type>1</payment_type><subject>测试</subject><trade_no>2014080239826696</trade_no><buyer_email>xxx@gmail.com</buyer_email><gmt_create>2014-08-02 14:49:13</gmt_create><notify_type>trade_status_sync</notify_type><quantity>1</quantity><out_trade_no>BD8Y9JQ2LT8MVXLMT34RTUWEMMBAXMIGBVQGF5CQNZHPYPQHSD4MEI56NQD2OLNV</out_trade_no><notify_time>2014-08-02 15:14:25</notify_time><seller_id>2088411445328172</seller_id><trade_status>TRADE_FINISHED</trade_status><is_total_fee_adjust>N</is_total_fee_adjust><total_fee>0.03</total_fee><gmt_payment>2014-08-02 14:49:27</gmt_payment><seller_email>lxneng@gmail.com</seller_email><gmt_close>2014-08-02 14:49:27</gmt_close><price>0.03</price><buyer_id>2088002293077967</buyer_id><notify_id>6a40ac71fcf17d99b5274b0c6c8970ea7c</notify_id><use_coupon>N</use_coupon></notify>',
                   'service': 'alipay.wap.trade.create.direct',
                   'sign': '1f0a524dc51ed5bfc7ee2bac62e39534'}

--- a/src/alipay/tests.py
+++ b/src/alipay/tests.py
@@ -83,7 +83,7 @@ class AlipayTests(unittest.TestCase):
     def test_raise_parameter_value_error_when_initializing(self):
         from .exceptions import ParameterValueError
         self.assertRaises(ParameterValueError,
-                          self.Alipay(pid='pid', key='key'))
+                          self.Alipay, pid='pid', key='key')
 
     def test_create_wap_direct_pay_by_user_url(self):
         params = {'out_trade_no': '1',

--- a/src/alipay/tests.py
+++ b/src/alipay/tests.py
@@ -80,6 +80,12 @@ class AlipayTests(unittest.TestCase):
                           self.alipay.create_direct_pay_by_user_url,
                           **params)
 
+    def test_raise_parameter_value_error_when_initializing(self):
+        from .exceptions import MissingParameter
+        faile_alipay = self.Alipay(pid='pid', key='key')
+        self.assertRaises(ParameterValueError,
+                          self.Alipay(pid='pid', key='key'))
+
     def test_create_wap_direct_pay_by_user_url(self):
         params = {'out_trade_no': '1',
                   'subject': u'测试',


### PR DESCRIPTION
1. Add support to use `seller_id` instead of `seller_email` (when initialization)
2. Polish some style problems (whitespace, indent, etc.)
3. Update README and unit tests correspondingly.