### PR TITLE
Fix argument type error of verify_notify in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ verify notify from alipay server, example in Pyramid Application
 
     def alipy_notify(request):
     	alipay = request.registry['alipay']
-    	if alipay.verify_notify(request.params):
+    	if alipay.verify_notify(**request.params):
     		# this is a valid notify, code business logic here
     	else:
     	    # this is a invalid notify


### PR DESCRIPTION
According to the source, verify_notify should accept kwargs instead of a whole dict.