### PR TITLE
FIX SEVERE FAULT IN `check_notify_remotely`!

### DIFF
--- a/src/alipay/__init__.py
+++ b/src/alipay/__init__.py
@@ -127,7 +127,7 @@ class Alipay(object):
     def check_notify_remotely(self, **kw):
         remote_result = requests.get(self.NOTIFY_GATEWAY_URL % (self.pid, kw['notify_id']),
                                      headers={'connection': 'close'}).text
-        return remote_result is 'true'
+        return remote_result == 'true'
 
 '''Wap支付接口'''
 


### PR DESCRIPTION
Two strings are not safe to compare using 'is'. Sometimes it will give the 'right' result, if the cpython "internalize" the string literals. Otherwise, two same strings might have different IDs.

http://stackoverflow.com/questions/1504717/why-does-comparing-strings-in-python-using-either-or-is-sometimes-produce